### PR TITLE
feat(appointments): Implement get and delete functionality for appointments

### DIFF
--- a/src/main/java/com/dentpulse/dentalsystem/controller/AppointmentController.java
+++ b/src/main/java/com/dentpulse/dentalsystem/controller/AppointmentController.java
@@ -37,4 +37,20 @@ public class AppointmentController {
         );
     }
 
+    @GetMapping("/my-appointments")
+    public ResponseEntity<List<AppointmentResponseDto>> getMyAppointments(@RequestHeader("Authorization") String token) {
+        List<AppointmentResponseDto> appointments = appointmentService.getAppointmentsForUserAndFamily(token.substring(7));
+        return ResponseEntity.ok(appointments);
+    }
+
+    // Cancel an appointment (DELETE)
+    @DeleteMapping("/{appointmentId}")
+    public ResponseEntity<?> cancelAppointment(
+            @PathVariable Long appointmentId,
+            @RequestHeader("Authorization") String token
+    ) {
+        appointmentService.cancelAppointment(appointmentId, token.substring(7));
+        return ResponseEntity.ok("Appointment has been cancelled successfully");
+    }
+
 }

--- a/src/main/java/com/dentpulse/dentalsystem/dto/AppointmentResponseDto.java
+++ b/src/main/java/com/dentpulse/dentalsystem/dto/AppointmentResponseDto.java
@@ -10,4 +10,5 @@ public class AppointmentResponseDto {
     private String appointmentDate;
     private String startTime;
     private String status;
+    private String fullName;
 }

--- a/src/main/java/com/dentpulse/dentalsystem/repository/AppointmentRepository.java
+++ b/src/main/java/com/dentpulse/dentalsystem/repository/AppointmentRepository.java
@@ -24,4 +24,7 @@ public interface AppointmentRepository extends JpaRepository<Appointment, Long> 
             LocalDate appointmentDate,
             AppointmentStatus status
     );
+
+    // Get all appointments for a specific patient (including cancelled)
+    List<Appointment> findByPatientId(Long patientId);
 }


### PR DESCRIPTION
This PR adds functionality to the appointment page, allowing users to:
- View all appointments for themselves and their family members.
- Cancel (delete) appointments if necessary.

The following functionalities have been implemented:
- Fetching all appointments for a user and their family.
- Canceling (deleting) appointments directly from the appointments page.
- Ensured only the user or an admin can cancel an appointment.

Additionally, appointments will be displayed with the correct status, including canceled appointments, and will be updated dynamically on the front end.

This feature is part of the overall improvements to the patient management system.
