### PR TITLE
Add forgot password flow with OTP verification

### DIFF
--- a/src/main/java/com/dentpulse/dentalsystem/config/JwtAuthFilter.java
+++ b/src/main/java/com/dentpulse/dentalsystem/config/JwtAuthFilter.java
@@ -23,6 +23,13 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     @Autowired
     private UserRepository userRepo;
 
+    //  ADD THIS for forget password
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getServletPath();
+        return path.startsWith("/api/v1/auth/");
+    }
+
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,

--- a/src/main/java/com/dentpulse/dentalsystem/controller/AuthController.java
+++ b/src/main/java/com/dentpulse/dentalsystem/controller/AuthController.java
@@ -38,4 +38,39 @@ public class AuthController {
     public ResponseEntity<String> me() {
         return ResponseEntity.ok("Authenticated");
     }
+
+    @PostMapping("/forgot-password")
+    public ResponseEntity<String> forgotPassword(
+            @RequestBody ForgotPasswordRequest request
+    ) {
+        authService.sendForgotPasswordOtp(request.getEmail());
+        return ResponseEntity.ok("OTP sent to your email");
+    }
+
+    @PostMapping("/forgot-password/verify-otp")
+    public ResponseEntity<String> verifyForgotPasswordOtp(
+            @RequestBody VerifyForgotPasswordOtpRequest request
+    ) {
+        authService.verifyForgotPasswordOtp(
+                request.getEmail(),
+                request.getOtp()
+        );
+
+        return ResponseEntity.ok("OTP verified successfully");
+    }
+
+    @PostMapping("/forgot-password/reset")
+    public ResponseEntity<String> resetPassword(
+            @RequestBody ResetPasswordRequest request
+    ) {
+        authService.resetPassword(
+                request.getEmail(),
+                request.getNewPassword()
+        );
+
+        return ResponseEntity.ok("Password reset successful");
+    }
+
+
+
 }

--- a/src/main/java/com/dentpulse/dentalsystem/dto/ForgotPasswordRequest.java
+++ b/src/main/java/com/dentpulse/dentalsystem/dto/ForgotPasswordRequest.java
@@ -1,0 +1,8 @@
+package com.dentpulse.dentalsystem.dto;
+
+import lombok.Data;
+
+@Data
+public class ForgotPasswordRequest {
+    private String email;
+}

--- a/src/main/java/com/dentpulse/dentalsystem/dto/ResetPasswordRequest.java
+++ b/src/main/java/com/dentpulse/dentalsystem/dto/ResetPasswordRequest.java
@@ -1,0 +1,9 @@
+package com.dentpulse.dentalsystem.dto;
+
+import lombok.Data;
+
+@Data
+public class ResetPasswordRequest {
+    private String email;
+    private String newPassword;
+}

--- a/src/main/java/com/dentpulse/dentalsystem/dto/VerifyForgotPasswordOtpRequest.java
+++ b/src/main/java/com/dentpulse/dentalsystem/dto/VerifyForgotPasswordOtpRequest.java
@@ -1,0 +1,9 @@
+package com.dentpulse.dentalsystem.dto;
+
+import lombok.Data;
+
+@Data
+public class VerifyForgotPasswordOtpRequest {
+    private String email;
+    private String otp;
+}

--- a/src/main/java/com/dentpulse/dentalsystem/entity/User.java
+++ b/src/main/java/com/dentpulse/dentalsystem/entity/User.java
@@ -57,6 +57,11 @@ public class User implements UserDetails {
     @Column(name = "otp_expires_at")
     private LocalDateTime otpExpiresAt;
 
+    @Column(name = "forgot_password_verified")
+    private Boolean forgotPasswordVerified = false;
+
+
+
     // full name getter/setter
 
     public String getUserName() {


### PR DESCRIPTION
### What was added
- Forgot password API to send OTP to email
- OTP verification endpoint (one-time, 10 minutes expiry)
- Secure password reset only after OTP verification
- Reused existing EmailService for OTP sending

### Security
- OTP is single-use
- OTP expires after 10 minutes
- Password reset is blocked if OTP is not verified

### Notes
- No impact on existing login and email verification flow
- Works with existing User entity and JWT security setup
