### PR TITLE
Fix appointment slot availability and patient delete rules

### DIFF
--- a/src/main/java/com/dentpulse/dentalsystem/dto/AppointmentResponseDto.java
+++ b/src/main/java/com/dentpulse/dentalsystem/dto/AppointmentResponseDto.java
@@ -11,4 +11,6 @@ public class AppointmentResponseDto {
     private String startTime;
     private String status;
     private String fullName;
+
+    private String type;
 }

--- a/src/main/java/com/dentpulse/dentalsystem/entity/Appointment.java
+++ b/src/main/java/com/dentpulse/dentalsystem/entity/Appointment.java
@@ -39,6 +39,10 @@ public class Appointment {
     @Column(nullable = false)
     private AppointmentStatus status;
 
+    //  JUST STRING (admin will update later)
+    @Column(name = "type", nullable = false)
+    private String type;
+
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
@@ -52,5 +56,8 @@ public class Appointment {
     public void onCreate() {
         if (createdAt == null) createdAt = LocalDateTime.now();
         if (status == null) status = AppointmentStatus.PENDING;
+        if (type == null) {
+            type = "Checkup"; //  DEFAULT
+        }
     }
 }

--- a/src/main/java/com/dentpulse/dentalsystem/repository/AppointmentRepository.java
+++ b/src/main/java/com/dentpulse/dentalsystem/repository/AppointmentRepository.java
@@ -16,17 +16,17 @@ import java.util.List;
 public interface AppointmentRepository extends JpaRepository<Appointment, Long> {
 
     // Check if a time slot is already booked (except CANCELLED)
-    boolean existsByAppointmentDateAndStartTimeAndStatusNot(
-            LocalDate appointmentDate,
-            LocalTime startTime,
-            AppointmentStatus status
-    );
-
-    // Get all booked time slots for a given date (except CANCELLED)
-    List<Appointment> findByAppointmentDateAndStatusNot(
-            LocalDate appointmentDate,
-            AppointmentStatus status
-    );
+//    boolean existsByAppointmentDateAndStartTimeAndStatusNot(
+//            LocalDate appointmentDate,
+//            LocalTime startTime,
+//            AppointmentStatus status
+//    );
+//
+//    // Get all booked time slots for a given date (except CANCELLED)
+//    List<Appointment> findByAppointmentDateAndStatusNot(
+//            LocalDate appointmentDate,
+//            AppointmentStatus status
+//    );
 
     // Get all appointments for a specific patient (including cancelled)
     List<Appointment> findByPatientId(Long patientId);
@@ -34,6 +34,38 @@ public interface AppointmentRepository extends JpaRepository<Appointment, Long> 
     /*
     List<Appointment> findByAppointment_dateOrderByStartTimeAsc(Date appointmentDate);
     */
+
+    /*
+     Checks whether a given time slot is already blocked by an active appointment.
+
+     A time slot is considered BLOCKED only if there exists an appointment
+     on the given date and time whose status indicates the patient may still arrive
+     (PENDING, CONFIRMED, or SCHEDULED).
+
+      This is used when creating a new appointment to prevent double booking.
+     */
+    boolean existsByAppointmentDateAndStartTimeAndStatusIn(
+            LocalDate appointmentDate,
+            LocalTime startTime,
+            List<AppointmentStatus> statuses
+    );
+
+
+    /*
+     * Retrieves all appointments for a given date that actively block time slots.
+
+     Only appointments whose status indicates the patient may still come
+     (PENDING, CONFIRMED, or SCHEDULED) are returned.
+     This is used to determine which time slots should appear as unavailable
+     when displaying available booking times to patients.
+     */
+
+    List<Appointment> findByAppointmentDateAndStatusIn(
+            LocalDate appointmentDate,
+            List<AppointmentStatus> statuses
+    );
+
+
 
     long countByStatus(AppointmentStatus status);
 


### PR DESCRIPTION
### Summary
This PR improves patient-side appointment handling by fixing time slot availability logic and refining appointment deletion rules.

### Key Changes
- Updated slot availability logic to block time slots only for active appointments (PENDING, CONFIRMED, SCHEDULED).
- Ensured time slots are freed when appointments are COMPLETED, CANCELLED, or marked as NO_SHOW.
- Updated patient delete rules to allow deletion only for PENDING and CANCELLED appointments.
- Prevented double booking while keeping completed/cancelled slots reusable.

### Impact
- Improves booking accuracy and prevents unnecessary slot blocking.
- Maintains correct appointment history while allowing safe cleanup of unused records.
- Aligns backend behavior with real clinic workflows.

### Testing
- Verified appointment creation, cancellation, completion, and re-booking using Postman.
- Confirmed slot availability updates correctly after each status change.
