### PR TITLE
Improve email verification flow with resend OTP and unverified user handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,12 @@
 
 
 
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.6.0</version>
+		</dependency>
+
 
 
 

--- a/src/main/java/com/dentpulse/dentalsystem/config/SecurityConfig.java
+++ b/src/main/java/com/dentpulse/dentalsystem/config/SecurityConfig.java
@@ -34,6 +34,12 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/v1/auth/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**"
+                        ).permitAll()
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers("/api/**").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/dentpulse/dentalsystem/controller/AuthController.java
+++ b/src/main/java/com/dentpulse/dentalsystem/controller/AuthController.java
@@ -28,6 +28,13 @@ public class AuthController {
         return ResponseEntity.ok(msg);
     }
 
+    @PostMapping("/resend-otp")
+    public ResponseEntity<String> resendOtp(@RequestBody ForgotPasswordRequest request) {
+        authService.resendVerifyOtp(request.getEmail());
+        return ResponseEntity.ok("OTP resent to your email");
+    }
+
+
 
     @PostMapping("/login")
     public ResponseEntity<LoginResponseDto> login(@RequestBody LoginRequest dto) {

--- a/src/main/java/com/dentpulse/dentalsystem/dto/FamilyMemberDto.java
+++ b/src/main/java/com/dentpulse/dentalsystem/dto/FamilyMemberDto.java
@@ -10,5 +10,7 @@ public class FamilyMemberDto {
     private String phone;
     private String relationship;
     private String gender;
+    private String birthDate;
+    private String address;
     private boolean accountOwner;
 }

--- a/src/main/java/com/dentpulse/dentalsystem/repository/PatientRepository.java
+++ b/src/main/java/com/dentpulse/dentalsystem/repository/PatientRepository.java
@@ -18,4 +18,7 @@ public interface PatientRepository extends JpaRepository<Patient, Long> {
 
     // Get only family members (exclude account owner)
     List<Patient> findByUserIdAndAccountOwnerFalse(Long userId);
+
+    Optional<Patient> findFirstByUserIdAndAccountOwnerTrue(Long userId);
+
 }

--- a/src/main/java/com/dentpulse/dentalsystem/service/PatientSelfService.java
+++ b/src/main/java/com/dentpulse/dentalsystem/service/PatientSelfService.java
@@ -231,6 +231,8 @@ public class PatientSelfService {
             dto.setRelationship(p.getRelationship());
             dto.setAccountOwner(p.isAccountOwner());
             dto.setGender(p.getGender());
+            dto.setBirthDate(p.getDateOfBirth() != null ? p.getDateOfBirth().toString() : null);
+            dto.setAddress(p.getAddress());
 
             result.add(dto);
         }


### PR DESCRIPTION
### Summary
This PR improves the patient registration and email verification flow to prevent users from getting stuck when OTP expires or the verification page is closed.

### Key Changes
- Allow re-registration using the same email if the user is not yet email-verified
- Regenerate and resend OTP for unverified users instead of blocking registration
- Added resend OTP support to handle OTP expiry scenarios
- Ensure patient (account owner) record is reused and updated without duplication
- Clear OTP and verification flags correctly after successful verification

### Problem Solved
Previously, users who failed to verify their email within the OTP expiry time could not re-register using the same email. This change ensures a smooth and recoverable registration experience.

### Impact
- Improved user experience
- No duplicate users or patients
- Secure and consistent email verification logic
- Aligns with real-world authentication flows
- And add some security config and address ,birth date