### PR TITLE
Add admin dashboard support for today’s appointments (v1 APIs)

### DIFF
--- a/src/main/java/com/dentpulse/dentalsystem/controller/AdminAppointmentController.java
+++ b/src/main/java/com/dentpulse/dentalsystem/controller/AdminAppointmentController.java
@@ -3,6 +3,7 @@ package com.dentpulse.dentalsystem.controller;
 import com.dentpulse.dentalsystem.dto.AppointmentResponseDto;
 import com.dentpulse.dentalsystem.service.AppointmentService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -10,7 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/api/admin/appointments")
+@RequestMapping("/api/v1/admin/appointments")
 @CrossOrigin(origins = "http://localhost:3000")
 public class AdminAppointmentController {
 
@@ -24,8 +25,10 @@ public class AdminAppointmentController {
 
     // Filter by date
     @GetMapping("/by-date")
-    public List<AppointmentResponseDto> getByDate(@RequestParam String date) {
-        return appointmentService.getAppointmentsByDate(LocalDate.parse(date));
+    public List<AppointmentResponseDto> getByDate(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate  date)
+    {
+        return appointmentService.getAppointmentsByDate(date);
     }
 
     // Summary cards
@@ -34,4 +37,3 @@ public class AdminAppointmentController {
         return appointmentService.getAdminAppointmentStats();
     }
 }
-


### PR DESCRIPTION
### Summary
This PR updates the admin appointment APIs to follow the `/api/v1` versioning standard and enables loading today’s appointments for the admin dashboard.

### Changes
- Updated admin-related appointment endpoints to include `v1` API versioning
- Integrated date-based appointment filtering to support displaying today’s appointments
- Ensured compatibility with existing admin dashboard functionality

### Example
http://localhost:8080//api/v1/admin/

----------------------------------------------------------------------------------
GET /api/v1/admin/appointments/by-date?date=yyyy-MM-dd


### Notes
- This change improves API consistency and future extensibility.
- No breaking changes to business logic.
