### PR TITLE
Make reviews instantly visible; disable approval flow; allow patient edit/delete (except removed)

### DIFF
--- a/src/main/java/com/dentpulse/dentalsystem/controller/ReviewController.java
+++ b/src/main/java/com/dentpulse/dentalsystem/controller/ReviewController.java
@@ -68,29 +68,29 @@ public class ReviewController {
 
     //admin part___
 
-    @GetMapping("/admin/pending")
-    @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<List<ReviewResponseDto>> getPendingReviews() {
-        return ResponseEntity.ok(
-                reviewService.getPendingReviews()
-        );
-    }
+//    @GetMapping("/admin/pending")
+//    @PreAuthorize("hasRole('ADMIN')")
+//    public ResponseEntity<List<ReviewResponseDto>> getPendingReviews() {
+//        return ResponseEntity.ok(
+//                reviewService.getPendingReviews()
+//        );
+//    }
 
     // ✅ Approve review
-    @PutMapping("/admin/{reviewId}/approve")
-    @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<?> approveReview(@PathVariable Long reviewId) {
-        reviewService.approveReview(reviewId);
-        return ResponseEntity.ok("Review approved successfully");
-    }
+//    @PutMapping("/admin/{reviewId}/approve")
+//    @PreAuthorize("hasRole('ADMIN')")
+//    public ResponseEntity<?> approveReview(@PathVariable Long reviewId) {
+//        reviewService.approveReview(reviewId);
+//        return ResponseEntity.ok("Review approved successfully");
+//    }
 
     // ❌ Reject review
-    @PutMapping("/admin/{reviewId}/reject")
-    @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<?> rejectReview(@PathVariable Long reviewId) {
-        reviewService.rejectReview(reviewId);
-        return ResponseEntity.ok("Review rejected successfully");
-    }
+//    @PutMapping("/admin/{reviewId}/reject")
+//    @PreAuthorize("hasRole('ADMIN')")
+//    public ResponseEntity<?> rejectReview(@PathVariable Long reviewId) {
+//        reviewService.rejectReview(reviewId);
+//        return ResponseEntity.ok("Review rejected successfully");
+//    }
 
     // 🔥 Remove approved review (soft delete)
     @PutMapping("/admin/{reviewId}/remove")

--- a/src/main/java/com/dentpulse/dentalsystem/service/ReviewService.java
+++ b/src/main/java/com/dentpulse/dentalsystem/service/ReviewService.java
@@ -72,7 +72,8 @@ public class ReviewService {
         review.setAppointment(appointment);
         review.setRating(request.getRating());
         review.setComment(request.getComment());
-        review.setStatus(ReviewStatus.PENDING);
+        //review.setStatus(ReviewStatus.PENDING);
+        review.setStatus(ReviewStatus.APPROVED); // immediate visible
 
         Review saved = reviewRepo.save(review);
 
@@ -154,8 +155,12 @@ public class ReviewService {
         }
 
         // Only PENDING can update
-        if (review.getStatus() != ReviewStatus.PENDING) {
-            throw new RuntimeException("Only pending reviews can be edited. Please contact clinic.");
+//        if (review.getStatus() != ReviewStatus.PENDING) {
+//            throw new RuntimeException("Only pending reviews can be edited. Please contact clinic.");
+//        }
+
+        if (review.getStatus() == ReviewStatus.REMOVED) {
+            throw new RuntimeException("Removed reviews cannot be edited.");
         }
 
         review.setRating(request.getRating());
@@ -194,8 +199,12 @@ public class ReviewService {
         }
 
         // Only PENDING can delete
-        if (review.getStatus() != ReviewStatus.PENDING) {
-            throw new RuntimeException("Only pending reviews can be deleted. Please contact clinic.");
+//        if (review.getStatus() != ReviewStatus.PENDING) {
+//            throw new RuntimeException("Only pending reviews can be deleted. Please contact clinic.");
+//        }
+
+        if (review.getStatus() == ReviewStatus.REMOVED) {
+            throw new RuntimeException("Removed reviews cannot be deleted.");
         }
 
         // 🔥 BREAK RELATIONSHIP FIRST
@@ -208,58 +217,58 @@ public class ReviewService {
 
     //admin part__
 
-    public List<ReviewResponseDto> getPendingReviews() {
+//    public List<ReviewResponseDto> getPendingReviews() {
+//
+//        List<Review> reviews = reviewRepo.findByStatus(ReviewStatus.PENDING);
+//
+//        List<ReviewResponseDto> result = new ArrayList<>();
+//
+//        for (Review review : reviews) {
+//
+//            Appointment appointment = review.getAppointment();
+//            Patient patient = appointment.getPatient();
+//
+//            ReviewResponseDto dto = new ReviewResponseDto();
+//            dto.setReviewId(review.getId());
+//            dto.setAppointmentId(appointment.getId());
+//            dto.setPatientId(patient.getId());
+//            dto.setPatientName(patient.getFullName());
+//            dto.setRating(review.getRating());
+//            dto.setComment(review.getComment());
+//            dto.setStatus(review.getStatus());
+//            dto.setCreatedAt(review.getCreatedAt());
+//
+//            result.add(dto);
+//        }
+//
+//        return result;
+//    }
 
-        List<Review> reviews = reviewRepo.findByStatus(ReviewStatus.PENDING);
+//    public void approveReview(Long reviewId) {
+//
+//        Review review = reviewRepo.findById(reviewId)
+//                .orElseThrow(() -> new RuntimeException("Review not found"));
+//
+//        if (review.getStatus() != ReviewStatus.PENDING) {
+//            throw new RuntimeException("Only pending reviews can be approved");
+//        }
+//
+//        review.setStatus(ReviewStatus.APPROVED);
+//        reviewRepo.save(review);
+//    }
 
-        List<ReviewResponseDto> result = new ArrayList<>();
-
-        for (Review review : reviews) {
-
-            Appointment appointment = review.getAppointment();
-            Patient patient = appointment.getPatient();
-
-            ReviewResponseDto dto = new ReviewResponseDto();
-            dto.setReviewId(review.getId());
-            dto.setAppointmentId(appointment.getId());
-            dto.setPatientId(patient.getId());
-            dto.setPatientName(patient.getFullName());
-            dto.setRating(review.getRating());
-            dto.setComment(review.getComment());
-            dto.setStatus(review.getStatus());
-            dto.setCreatedAt(review.getCreatedAt());
-
-            result.add(dto);
-        }
-
-        return result;
-    }
-
-    public void approveReview(Long reviewId) {
-
-        Review review = reviewRepo.findById(reviewId)
-                .orElseThrow(() -> new RuntimeException("Review not found"));
-
-        if (review.getStatus() != ReviewStatus.PENDING) {
-            throw new RuntimeException("Only pending reviews can be approved");
-        }
-
-        review.setStatus(ReviewStatus.APPROVED);
-        reviewRepo.save(review);
-    }
-
-    public void rejectReview(Long reviewId) {
-
-        Review review = reviewRepo.findById(reviewId)
-                .orElseThrow(() -> new RuntimeException("Review not found"));
-
-        if (review.getStatus() != ReviewStatus.PENDING) {
-            throw new RuntimeException("Only pending reviews can be rejected");
-        }
-
-        review.setStatus(ReviewStatus.REJECTED);
-        reviewRepo.save(review);
-    }
+//    public void rejectReview(Long reviewId) {
+//
+//        Review review = reviewRepo.findById(reviewId)
+//                .orElseThrow(() -> new RuntimeException("Review not found"));
+//
+//        if (review.getStatus() != ReviewStatus.PENDING) {
+//            throw new RuntimeException("Only pending reviews can be rejected");
+//        }
+//
+//        review.setStatus(ReviewStatus.REJECTED);
+//        reviewRepo.save(review);
+//    }
 
     public void removeReview(Long reviewId) {
 


### PR DESCRIPTION
 Review Flow Simplification
 What Changed

Reviews are now visible immediately after patient submission

Admin approval & reject flow has been temporarily disabled (commented out)

Patients can:

 Edit their review

 Delete their review
(Only restricted if status = REMOVED)

Admin can still:

 Remove approved reviews (soft delete)

 Logic Updates

createReview() → status set to APPROVED

updateReview() → allowed unless review is REMOVED

deleteReview() → allowed unless review is REMOVED

Approval-related endpoints commented for future reactivation

 Reason

To simplify the review process and:

Remove moderation delay

Improve user experience

Keep flexibility for future moderation re-implementation