### PR TITLE
Add HTML email template for OTP messages

### DIFF
--- a/src/main/java/com/dentpulse/dentalsystem/service/EmailService.java
+++ b/src/main/java/com/dentpulse/dentalsystem/service/EmailService.java
@@ -1,8 +1,10 @@
 package com.dentpulse.dentalsystem.service;
 
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -18,15 +20,91 @@ public class EmailService {
     }
 
     public void sendOtpEmail(String toEmail, String otpCode) {
-        SimpleMailMessage message = new SimpleMailMessage();
-        message.setFrom(fromEmail);
-        message.setTo(toEmail);
-        message.setSubject("DentPulse - Email Verification Code");
-        message.setText(
-                "Your DentPulse verification code is: " + otpCode +
-                        "\nThis code will expire in 10 minutes."
-        );
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, "UTF-8");
 
-        mailSender.send(message);
+            helper.setFrom(fromEmail);
+            helper.setTo(toEmail);
+            helper.setSubject("DentPulse - Email Verification Code");
+            helper.setText(buildOtpEmailTemplate(otpCode), true);
+
+            mailSender.send(message);
+
+        } catch (MessagingException e) {
+            throw new RuntimeException("Failed to send OTP email", e);
+        }
+    }
+
+    private String buildOtpEmailTemplate(String otpCode) {
+        return """
+                <!DOCTYPE html>
+                <html>
+                <head>
+                    <meta charset="UTF-8">
+                    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                    <title>DentPulse Email Verification</title>
+                </head>
+                <body style="margin:0; padding:0; background-color:#0f1f17; font-family:Arial, sans-serif;">
+                
+                    <table role="presentation" width="100%%" cellspacing="0" cellpadding="0" border="0" 
+                           style="background-color:#0f1f17; padding:30px 0;">
+                        <tr>
+                            <td align="center">
+                
+                                <table role="presentation" width="100%%" cellspacing="0" cellpadding="0" border="0"
+                                       style="max-width:600px; background-color:#13271d; border-radius:16px; overflow:hidden; box-shadow:0 6px 20px rgba(0,0,0,0.25);">
+                                    
+                                    <tr>
+                                        <td align="center" style="padding:35px 20px 20px 20px; background-color:#163222;">
+                                            <h1 style="margin:0; font-size:38px; color:#2ecc71; font-weight:700;">DentPulse</h1>
+                                            <p style="margin:10px 0 0 0; font-size:16px; color:#d6f5df;">
+                                                Smart Dental Care Platform
+                                            </p>
+                                        </td>
+                                    </tr>
+                
+                                    <tr>
+                                        <td style="padding:40px 35px; color:#ffffff;">
+                                            <h2 style="margin:0 0 15px 0; font-size:30px; color:#2ecc71;">
+                                                Email Verification
+                                            </h2>
+                
+                                            <p style="margin:0 0 15px 0; font-size:17px; line-height:1.7; color:#e8f5ec;">
+                                                Welcome to <strong>DentPulse</strong>!
+                                            </p>
+                
+                                            <p style="margin:0 0 25px 0; font-size:16px; line-height:1.8; color:#dbeee1;">
+                                                Use the verification code below to complete your registration.
+                                                This code will expire in <strong>10 minutes</strong>.
+                                            </p>
+                
+                                            <div style="text-align:center; margin:30px 0;">
+                                                <div style="display:inline-block; background-color:#2ecc71; color:#0f1f17; 
+                                                            font-size:34px; font-weight:bold; letter-spacing:10px; 
+                                                            padding:18px 30px; border-radius:12px;">
+                                                    %s
+                                                </div>
+                                            </div>
+                
+                                            <p style="margin:25px 0 0 0; font-size:14px; line-height:1.7; color:#b9d7c2;">
+                                                If you did not request this verification, please ignore this email.
+                                            </p>
+                                        </td>
+                                    </tr>
+                
+                                    <tr>
+                                        <td align="center" style="padding:20px; border-top:1px solid #244533; color:#9fc3aa; font-size:13px;">
+                                            © 2026 DentPulse. All rights reserved.
+                                        </td>
+                                    </tr>
+                                </table>
+                
+                            </td>
+                        </tr>
+                    </table>
+                </body>
+                </html>
+                """.formatted(otpCode);
     }
 }


### PR DESCRIPTION
## Feature: HTML Email Template for OTP

This update replaces the plain text OTP email with a styled HTML email template to improve user experience and branding.

### Changes
- Replaced `SimpleMailMessage` with `MimeMessage` to support HTML emails.
- Added a custom HTML email template for OTP verification.
- Styled the email using DentPulse theme colors (dark green).
- Display OTP code in a highlighted box for better visibility.
- Improved layout with header, content section, and footer.

### Technical Details
- Introduced `MimeMessageHelper` for sending HTML formatted emails.
- Added `buildOtpEmailTemplate()` method to generate dynamic email content.
- OTP code is injected into the template using Java string formatting.

### Result
Users now receive a modern, branded email instead of a plain text OTP message.

### Example Improvements
Before:
Plain text OTP email.

After:
Styled DentPulse email with:
- branded header
- verification instructions
- highlighted OTP code
- responsive layout