### PR TITLE
Add analytics charts for admin dashboard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,11 +66,13 @@
 			<version>1.18.32</version>
 			<optional>true</optional>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-tomcat</artifactId>
-			<scope>provided</scope>
+			<!--<scope>provided</scope>	-->
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/src/main/java/com/dentpulse/dentalsystem/controller/AdminStatsController.java
+++ b/src/main/java/com/dentpulse/dentalsystem/controller/AdminStatsController.java
@@ -1,0 +1,42 @@
+package com.dentpulse.dentalsystem.controller;
+
+import com.dentpulse.dentalsystem.service.AdminStatsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/admin/stats")
+@RequiredArgsConstructor
+public class AdminStatsController {
+
+    private final AdminStatsService statsService;
+
+    @GetMapping("/monthly-revenue")
+    public List<Map<String,Object>> monthlyRevenue(){
+
+        return statsService.getMonthlyRevenue();
+    }
+
+    @GetMapping("/appointment-times")
+    public List<Map<String,Object>> appointmentTimes(){
+
+        return statsService.getAppointmentTimes();
+    }
+
+    @GetMapping("/treatment-stats")
+    public List<Map<String,Object>> treatmentStats(){
+
+        return statsService.getTreatmentStats();
+    }
+
+    @GetMapping("/appointments-by-day")
+    public List<Map<String,Object>> appointmentsByDay(){
+
+        return statsService.getAppointmentsByDay();
+    }
+}

--- a/src/main/java/com/dentpulse/dentalsystem/repository/AppointmentRepository.java
+++ b/src/main/java/com/dentpulse/dentalsystem/repository/AppointmentRepository.java
@@ -100,4 +100,24 @@ public interface AppointmentRepository extends JpaRepository<Appointment, Long> 
             AppointmentStatus status
     );
 
+    @Query("""
+    SELECT 
+        FUNCTION('DATE_FORMAT', a.startTime, '%H:00'),
+        COUNT(a)
+    FROM Appointment a
+    GROUP BY FUNCTION('DATE_FORMAT', a.startTime, '%H:00')
+    ORDER BY FUNCTION('DATE_FORMAT', a.startTime, '%H:00')
+    """)
+    List<Object[]> getAppointmentsByTime();
+
+
+    @Query("""
+    SELECT 
+        FUNCTION('DAYNAME', a.appointmentDate),
+        COUNT(a)
+    FROM Appointment a
+    GROUP BY FUNCTION('DAYNAME', a.appointmentDate)
+    """)
+    List<Object[]> getAppointmentsByDay();
+
 }

--- a/src/main/java/com/dentpulse/dentalsystem/repository/BillRepository.java
+++ b/src/main/java/com/dentpulse/dentalsystem/repository/BillRepository.java
@@ -25,4 +25,14 @@ public interface BillRepository extends JpaRepository<Bill, Long> {
 
     @Query("SELECT COALESCE(SUM(b.amount),0) FROM Bill b WHERE b.billDate = :date")
     Double getTodayRevenue(@Param("date") LocalDate date);
+
+    @Query("""
+    SELECT 
+        FUNCTION('DATE_FORMAT', b.billDate, '%b') ,
+        SUM(b.amount)
+    FROM Bill b
+    GROUP BY FUNCTION('DATE_FORMAT', b.billDate, '%b')
+    ORDER BY MIN(b.billDate)
+    """)
+    List<Object[]> getMonthlyRevenue();
 }

--- a/src/main/java/com/dentpulse/dentalsystem/repository/TreatmentRecordRepository.java
+++ b/src/main/java/com/dentpulse/dentalsystem/repository/TreatmentRecordRepository.java
@@ -2,6 +2,7 @@ package com.dentpulse.dentalsystem.repository;
 
 import com.dentpulse.dentalsystem.entity.TreatmentRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -9,6 +10,15 @@ public interface TreatmentRecordRepository extends JpaRepository<TreatmentRecord
     List<TreatmentRecord> findByPatientId(Long patientId);
     // NEW - for treatment table view
     List<TreatmentRecord> findAll();
+
+    @Query("""
+    SELECT 
+        t.treatmentType,
+        COUNT(t)
+    FROM TreatmentRecord t
+    GROUP BY t.treatmentType
+    """)
+    List<Object[]> getTreatmentStats();
 }
 
 

--- a/src/main/java/com/dentpulse/dentalsystem/service/AdminStatsService.java
+++ b/src/main/java/com/dentpulse/dentalsystem/service/AdminStatsService.java
@@ -1,0 +1,97 @@
+package com.dentpulse.dentalsystem.service;
+
+import com.dentpulse.dentalsystem.repository.AppointmentRepository;
+import com.dentpulse.dentalsystem.repository.BillRepository;
+import com.dentpulse.dentalsystem.repository.TreatmentRecordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class AdminStatsService {
+
+    private final BillRepository billRepository;
+    private final AppointmentRepository appointmentRepository;
+    private final TreatmentRecordRepository treatmentRecordRepository;
+
+    // Monthly Revenue
+    public List<Map<String,Object>> getMonthlyRevenue(){
+
+        List<Object[]> results = billRepository.getMonthlyRevenue();
+        List<Map<String,Object>> data = new ArrayList<>();
+
+        for(Object[] row : results){
+
+            Map<String,Object> map = new HashMap<>();
+
+            map.put("month", row[0]);
+            map.put("revenue", row[1]);
+
+            data.add(map);
+        }
+
+        return data;
+    }
+
+    // Appointment Time Chart
+    public List<Map<String,Object>> getAppointmentTimes(){
+
+        List<Object[]> results = appointmentRepository.getAppointmentsByTime();
+        List<Map<String,Object>> data = new ArrayList<>();
+
+        for(Object[] row : results){
+
+            Map<String,Object> map = new HashMap<>();
+
+            map.put("time", row[0]);
+            map.put("count", row[1]);
+
+            data.add(map);
+        }
+
+        return data;
+    }
+
+    // Treatment Chart
+    public List<Map<String,Object>> getTreatmentStats(){
+
+        List<Object[]> results = treatmentRecordRepository.getTreatmentStats();
+        List<Map<String,Object>> data = new ArrayList<>();
+
+        for(Object[] row : results){
+
+            Map<String,Object> map = new HashMap<>();
+
+            map.put("treatment", row[0]);
+            map.put("count", row[1]);
+
+            data.add(map);
+        }
+
+        return data;
+    }
+
+    //Appointment Distribution by Day chart
+    public List<Map<String,Object>> getAppointmentsByDay(){
+
+        List<Object[]> results = appointmentRepository.getAppointmentsByDay();
+        List<Map<String,Object>> data = new ArrayList<>();
+
+        for(Object[] row : results){
+
+            Map<String,Object> map = new HashMap<>();
+
+            map.put("day", row[0]);
+            map.put("count", row[1]);
+
+            data.add(map);
+        }
+
+        return data;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.datasource.url=jdbc:mysql://localhost:3306/dentpulse?createDatabaseIfNotExist=true
 spring.datasource.username=root
-spring.datasource.password=Hvpmj271@
+spring.datasource.password=1234
 
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true


### PR DESCRIPTION
This PR introduces analytics charts to the admin dashboard to provide better insights into clinic operations.

Key changes:
- Added backend SQL queries to fetch analytics data from the database
- Implemented service and controller endpoints to expose statistics APIs
- Added frontend chart components for data visualization
- Integrated the following charts into the admin dashboard:
  - Monthly revenue chart
  - Appointment time distribution chart
  - Treatment distribution chart
  - Appointments by day chart

These improvements enhance the dashboard by providing useful visual insights for administrators.